### PR TITLE
fixed wrong error handling when polling for docker up state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for Lovely Pytest Docker
 unreleased
 ==========
 
+ - fixed wrong error handling when polling for docker up state
+
 2018/01/10 0.0.2
 ================
 

--- a/src/lovely/pytest/docker/compose.py
+++ b/src/lovely/pytest/docker/compose.py
@@ -6,7 +6,6 @@ import time
 import timeit
 
 from urllib.request import urlopen
-from urllib.error import URLError
 
 
 def check_url(docker_ip, public_port):
@@ -19,10 +18,7 @@ def check_url(docker_ip, public_port):
     try:
         r = urlopen(url)
         return r.status < 500
-    except URLError as e:
-        # If service returns e.g. a 404 it's ok
-        return e.code < 500
-    except Exception as e:
+    except Exception:
         # Possible service not yet started
         return False
 

--- a/src/lovely/pytest/docker/compose.py
+++ b/src/lovely/pytest/docker/compose.py
@@ -6,6 +6,7 @@ import time
 import timeit
 
 from urllib.request import urlopen
+from urllib.error import HTTPError
 
 
 def check_url(docker_ip, public_port):
@@ -18,6 +19,9 @@ def check_url(docker_ip, public_port):
     try:
         r = urlopen(url)
         return r.status < 500
+    except HTTPError as e:
+        # If service returns e.g. a 404 it's ok
+        return e.code < 500
     except Exception:
         # Possible service not yet started
         return False


### PR DESCRIPTION
The previous implementation was handling the URLError and was checking
for the code property.
URLError is not providing this property.