### PR TITLE
Added docker_services_project_name fixture

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changes for Lovely Pytest Docker
 ================================
 
+Unreleased
+==========
+
+ - added ``docker_services_project_name`` fixture in order to override the container
+   name prefix for started services.
+
 2019/01/22 0.0.5
 ================
 

--- a/src/lovely/pytest/docker/compose.py
+++ b/src/lovely/pytest/docker/compose.py
@@ -1,10 +1,10 @@
-import time
-
 import os
-import pytest
 import re
 import subprocess
+import time
 import timeit
+
+import pytest
 from six.moves.urllib.error import HTTPError
 from six.moves.urllib.request import urlopen
 
@@ -187,14 +187,23 @@ def docker_compose_files(pytestconfig):
 
 
 @pytest.fixture(scope='session')
-def docker_services(request, pytestconfig, docker_compose_files, docker_ip):
+def docker_services_project_name(pytestconfig):
+    project_name = "pytest{}".format(str(pytestconfig.rootdir))
+    return project_name
+
+
+@pytest.fixture(scope='session')
+def docker_services(request, docker_compose_files, docker_ip, docker_services_project_name):
     """Provide the docker services as a pytest fixture.
 
     The services will be stopped after all tests are run.
     """
     keep_alive = request.config.getoption("--keepalive", False)
-    project_name = "pytest{}".format(str(pytestconfig.rootdir))
-    services = Services(docker_compose_files, docker_ip, project_name)
+    services = Services(
+        docker_compose_files,
+        docker_ip,
+        docker_services_project_name
+    )
     yield services
     if not keep_alive:
         services.shutdown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,3 +25,8 @@ def docker_hello_world2(docker_services):
     public_port = docker_services.wait_for_service("hello2", 80)
     url = "http://{docker_services.docker_ip}:{public_port}".format(**locals())
     return url
+
+
+@pytest.fixture(scope='session')
+def docker_services_project_name():
+    return "lovely-pytest-docker"

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -47,3 +47,12 @@ def test_custom_checker(docker_services):
 
     docker_services.wait_for_service("hello", 80, check_server=custom_checker)
     assert custom_checker_called > 1
+
+
+def test_custom_docker_service_project_name(docker_hello_world, docker_services):
+    """Test a custom project name for docker services.
+
+    Project name can be defined as fixture in conftest.py
+    """
+    res = docker_services._docker_compose.execute("ps")
+    assert 'lovely-pytest-docker' in res


### PR DESCRIPTION
This allows to override the container name prefix for started docker
services.