### PR TITLE
add support for Stopping a Docker Container

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ unreleased
 
 - allow to set the timeout and retry interval when waiting for services
 - added explicit dependency to six, which is no more required in newer pytest versions
+- add support for `docker-compose stop`
 
 2021/08/05 0.2.1
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,9 @@ Changes for Lovely Pytest Docker
 unreleased
 ==========
 
+- add support for `docker-compose stop`
 - allow to set the timeout and retry interval when waiting for services
 - added explicit dependency to six, which is no more required in newer pytest versions
-- add support for `docker-compose stop`
 
 2021/08/05 0.2.1
 ================

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,18 @@ the ``exec`` method of the ``docker_services`` fixture::
         res = docker_services.execute('crate', 'ls', '-a')
 
 
+Stopping a Docker Container
+=============================
+
+It's possible to stop single Docker containers. Use
+the ``stop`` method of the ``docker_services`` fixture::
+
+    def test_stop(docker_services):
+        # the first argument is the service name of the compose file,
+        # the following arguments build the command to run
+        res = docker_services.stop('crate')
+
+
 Wait for Service
 ================
 

--- a/src/lovely/pytest/docker/compose.py
+++ b/src/lovely/pytest/docker/compose.py
@@ -75,6 +75,15 @@ class Services(object):
         """
         self._docker_compose.execute('up', '--build', '-d', *services)
 
+
+    def stop(self, *services):
+        """Ensures that the given services are stopped via docker compose.
+
+        :param services: the names of the services as defined in compose file
+        """
+        self._docker_compose.execute('stop', *services)
+
+
     def execute(self, service, *cmd):
         """Execute a command inside a docker container.
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,4 +1,5 @@
 from six.moves.urllib.request import urlopen
+import time
 
 
 def test_hello_world(docker_hello_world):
@@ -19,6 +20,22 @@ def test_single_container(docker_hello_world, docker_services):
     res = docker_services._docker_compose.execute("ps")
     assert 'hello' in res
     assert 'hello2' not in res
+
+
+def test_stop_single_container(docker_hello_world, docker_hello_world2, docker_services):
+    """Test if only the requested containers are stope.
+
+    The container for hello2 is started by the fixture and stopped via function.
+    """
+    res = docker_services._docker_compose.execute("ps")
+    assert 'hello'  in res
+    assert 'hello2' in res
+    docker_services.stop("hello2")
+    res = docker_services._docker_compose.execute('ps', '--services', '--filter', 'status=running')
+    assert 'hello2' not in res
+    docker_services.start("hello2")
+    res = docker_services._docker_compose.execute('ps', '--services', '--filter', 'status=running')
+    assert 'hello2' in res
 
 
 def test_execute(docker_services):


### PR DESCRIPTION
fix #21 

* added `stop` function
* add test for `stop` function
* document `stop` function in README.MD
