### PR TITLE
remove prohibited chars from Docker compose project name

### DIFF
--- a/src/lovely/pytest/docker/compose.py
+++ b/src/lovely/pytest/docker/compose.py
@@ -207,7 +207,12 @@ def docker_compose_files(pytestconfig):
 
 @pytest.fixture(scope='session')
 def docker_services_project_name(pytestconfig):
-    project_name = "pytest{}".format(str(pytestconfig.rootdir))
+    """
+    Create unique project name for docker compose based on the pytestconfig root directory.
+    Characters prohibited by Docker compose project names are replaced with hyphens.
+    """
+    slug = re.sub(r'[^a-z0-9]+', '-', str(pytestconfig.rootdir).lower())
+    project_name = "pytest{}".format(slug)
     return project_name
 
 


### PR DESCRIPTION
Docker compose project names can no longer contain uppercase characters and slashes:
"project name MUST be lowercase by @ndeloof in https://github.com/docker/compose/pull/9385"
See:  https://github.com/docker/compose/releases/tag/v2.5.0

This PR modifies the fixture that generates project names and removes prohibited characters.